### PR TITLE
Changes in order to work with recent redis versions

### DIFF
--- a/spawn_redis_instance.sh
+++ b/spawn_redis_instance.sh
@@ -42,7 +42,7 @@ network_name=$( tr '_A-Z' '-a-z' <<< "${network:?}" )
 svc_name="${prefix:?}-redis"
 
 triton "${profile[@]}" "${account[@]}" inst create \
-  base-64-lts@19.4.0 g4-highcpu-4G \
+  base-64-lts@25.4.0 sample-1G \
   --name="${prefix:?}-redis-{{shortId}}" --network="${network:?}" \
   -m redis_token="${token:?}" \
   -m network_name="${network_name}" \


### PR DESCRIPTION
Hi *,

the redis_user-script.sh needs some changes in order to make this repo work with recent redis versions. 
1) I think the redis configuration has changed a bit, that had to be reflected in the patches
2) redis sentinel now changes the config files by using a tmp-file. This cannot be created in /opt/local/etc because of permission problems. That's why it is necessary to move the redis configuration files to /opt/local/etc/redis. This is accomplished by creating the respective directory (and setting the right permissions) as well as adding the required changes to the smf configuration.

The change in  spawn_redis_instance.sh is only for my triton lab setup. It can be ignored.

Have fun.